### PR TITLE
No longer require root element

### DIFF
--- a/xsd2json.js
+++ b/xsd2json.js
@@ -709,13 +709,16 @@ module.exports = {
         if (Array.isArray(rootElement)) {
             rootElement = rootElement[0];
         }
-        var rootElementName = rootElement["@name"];
-
-        obj.type = 'object';
-        obj.properties = clone(rootElement);
-
         obj.required = [];
-        obj.required.push(rootElementName);
+        obj.properties = {};
+        obj.type = 'object';
+        if (rootElement) {
+            var rootElementName = rootElement["@name"];
+
+
+            obj.properties = clone(rootElement);
+            obj.required.push(rootElementName);
+        }
         obj.additionalProperties = false;
 
         recurse(obj, {}, function (obj, parent, key) {


### PR DESCRIPTION
Schema generation fails if there is no root "name" element defined. This prevents type-definition only XSD files from being properly converted.

This change makes it no longer required to have a root element defined. This means the "property" field of the JSONSchema will be empty if there is no root element.