### PR TITLE
Allow selecting root element

### DIFF
--- a/xsd2json.js
+++ b/xsd2json.js
@@ -647,7 +647,7 @@ function recurse(obj, parent, callback, depthFirst) {
 }
 
 module.exports = {
-    getJsonSchema: function getJsonSchema(src, title, outputAttrPrefix, laxURIs, newXsPrefix) { // TODO convert to options parameter
+    getJsonSchema: function getJsonSchema(src, title, outputAttrPrefix, laxURIs, newXsPrefix, rootElementName) { // TODO convert to options parameter
         reset(outputAttrPrefix, laxURIs, newXsPrefix);
 
         for (let p in src) {
@@ -707,9 +707,12 @@ module.exports = {
 
         var rootElement = src[xsPrefix + "schema"][xsPrefix + "element"];
         if (Array.isArray(rootElement)) {
+            if (rootElementName !== undefined && rootElementName !== null && rootElementName !== '') {
+                rootElement.unshift(rootElement.splice(rootElement.findIndex(e => e["@name"] === rootElementName), 1)[0])
+            }
             rootElement = rootElement[0];
         }
-        var rootElementName = rootElement["@name"];
+        rootElementName = rootElement["@name"];
 
         obj.type = 'object';
         obj.properties = clone(rootElement);

--- a/xsd2json.js
+++ b/xsd2json.js
@@ -708,7 +708,10 @@ module.exports = {
         var rootElement = src[xsPrefix + "schema"][xsPrefix + "element"];
         if (Array.isArray(rootElement)) {
             if (rootElementName !== undefined && rootElementName !== null && rootElementName !== '') {
-                rootElement.unshift(rootElement.splice(rootElement.findIndex(e => e["@name"] === rootElementName), 1)[0])
+                var rootElementIndex = rootElement.findIndex(e => e["@name"] === rootElementName);
+                if (rootElementIndex >= 0) {
+                    rootElement.unshift(rootElement.splice(rootElementIndex, 1)[0]);
+                }
             }
             rootElement = rootElement[0];
         }


### PR DESCRIPTION
Hi!

I discovered, that if the XSD file just specifies a list of elements in arbitrary order, the root element is certainly wrong.
This PR is a quick and dirty fix to allow selecting the root element by name.
The element matching the name is moved to the first position of the array. The array is not modified if the name is not found.

Best regards
Josef